### PR TITLE
Remove trailing slash that makes command line fail

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ $ scope launch --service-token=&lt;token&gt;</pre>
   microservices-demo/deploy/kubernetes/manifests</pre>
     <p>Finally, <a target="_blank" href="https://cloud.weave.works/instances/create">create a new instance in Weave Cloud</a> and then run:</p>
     <pre>$ kubectl apply -f \
-  'https://cloud.weave.works/launch/k8s/weavescope.yaml\
+  'https://cloud.weave.works/launch/k8s/weavescope.yaml
 ?service-token=&lt;token&gt;'</pre>
     <p>Replacing <code>&lt;token&gt;</code> with your Weave Cloud token.</p>
 </div>


### PR DESCRIPTION
Because the URL is quoted, putting a backslash there means it goes into the URL and that will make the command fail. No backslash is required -- shell will wait for the quotes to be closed.
